### PR TITLE
[Py >= 3.7] Make code compatible with Python 3.7 and higher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "A prompting enhancement library for transformers-type text embedding systems."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU Affero General Public License v3",

--- a/src/compel/compel.py
+++ b/src/compel/compel.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Union, Optional, Callable
+from typing import Union, Optional, Callable, List, Tuple
 
 import torch
 from transformers import CLIPTokenizer, CLIPTextModel
@@ -51,7 +51,7 @@ class Compel:
         parsed_prompt = conjunction.prompts[0]
         return parsed_prompt
 
-    def describe_tokenization(self, text: str) -> list[str]:
+    def describe_tokenization(self, text: str) -> List[str]:
         """
         For the given text, return a list of strings showing how it will be tokenized.
 
@@ -63,7 +63,7 @@ class Compel:
         return self.conditioning_provider.tokenizer.tokenize(text)
 
     def build_conditioning_tensor_for_prompt_object(self, prompt: Union[Blend, FlattenedPrompt],
-                                                    ) -> tuple[torch.Tensor, dict]:
+                                                    ) -> Tuple[torch.Tensor, dict]:
         """
 
         """
@@ -79,7 +79,7 @@ class Compel:
         raise ValueError(f"unsupported prompt type: {type(prompt).__name__}")
 
     def _get_conditioning_for_flattened_prompt(self, prompt: FlattenedPrompt, should_return_tokens: bool=False
-                                               ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+                                               ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         if type(prompt) is not FlattenedPrompt:
             raise ValueError(f"embeddings can only be made from FlattenedPrompts, got {type(prompt).__name__} instead")
         fragments = [x.text for x in prompt.children]
@@ -175,6 +175,6 @@ class Compel:
         tokens = self.conditioning_provider.get_token_ids(texts, include_start_and_end_markers=False)
         return sum([len(x) for x in tokens])
 
-    def get_tokens(self, text: str) -> list[int]:
+    def get_tokens(self, text: str) -> List[int]:
         return self.conditioning_provider.get_token_ids([text], include_start_and_end_markers=False)[0]
 

--- a/src/compel/cross_attention_control.py
+++ b/src/compel/cross_attention_control.py
@@ -1,12 +1,13 @@
 import torch
+from typing import List
 
 
 class Arguments:
     def __init__(self,
                  original_conditioning: torch.Tensor,
                  edited_conditioning: torch.Tensor,
-                 edit_opcodes: list[tuple],
-                 edit_options: list[dict]):
+                 edit_opcodes: List[tuple],
+                 edit_options: List[dict]):
         """
         Arguments for a cross-attention control implementation that substitutes `edited_conditioning` for `original_conditioning` while applying the
         attention maps from `original_conditioning`.

--- a/src/compel/embeddings_provider.py
+++ b/src/compel/embeddings_provider.py
@@ -4,12 +4,13 @@ from typing import Callable, Union
 
 import torch
 from transformers import CLIPTokenizer, CLIPTextModel
+from typing import List, Tuple
 
 __all__ = ["EmbeddingsProvider"]
 
 
 class BaseTextualInversionManager(ABC):
-    def expand_textual_inversion_token_ids_if_necessary(self, token_ids: list[int]) -> list[int]:
+    def expand_textual_inversion_token_ids_if_necessary(self, token_ids: List[int]) -> List[int]:
         raise NotImplementedError()
 
 
@@ -35,7 +36,7 @@ class EmbeddingsProvider:
 
 
     @classmethod
-    def apply_embedding_weights(cls, embeddings: torch.Tensor, per_embedding_weights: list[float],
+    def apply_embedding_weights(cls, embeddings: torch.Tensor, per_embedding_weights: List[float],
                                 normalize: bool) -> torch.Tensor:
         per_embedding_weights = torch.tensor(per_embedding_weights, dtype=embeddings.dtype, device=embeddings.device)
         if normalize:
@@ -47,11 +48,11 @@ class EmbeddingsProvider:
         return blended_embeddings
 
     def get_embeddings_for_weighted_prompt_fragments(self,
-                                                     text_batch: list[list[str]],
-                                                     fragment_weights_batch: list[list[float]],
+                                                     text_batch: List[List[str]],
+                                                     fragment_weights_batch: List[List[float]],
                                                      should_return_tokens: bool = False,
                                                      device='cpu',
-                                 ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+                                 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         """
 
         :param text_batch: A list of fragments of text to which different weights are to be applied.
@@ -136,7 +137,7 @@ class EmbeddingsProvider:
         else:
             return batch_z
 
-    def get_token_ids(self, texts: list[str], include_start_and_end_markers: bool = True) -> list[list[int]]:
+    def get_token_ids(self, texts: List[str], include_start_and_end_markers: bool = True) -> List[List[int]]:
         """
         Convert a list of strings like `["a cat", "a dog", "monkey riding a bicycle"]` into a list of lists of token
         ids like `[[bos, 0, 1, eos], [bos, 0, 2, eos], [bos, 3, 4, 0, 5, eos]]`. bos/eos markers are skipped if
@@ -176,7 +177,7 @@ class EmbeddingsProvider:
 
         return result
 
-    def get_token_ids_and_expand_weights(self, fragments: list[str], weights: list[float], device: str) -> (torch.Tensor, torch.Tensor):
+    def get_token_ids_and_expand_weights(self, fragments: List[str], weights: List[float], device: str) -> (torch.Tensor, torch.Tensor):
         '''
         Given a list of text fragments and corresponding weights: tokenize each fragment, append the token sequences
         together and return a padded token sequence starting with the bos marker, ending with the eos marker, and padded

--- a/src/compel/prompt_parser.py
+++ b/src/compel/prompt_parser.py
@@ -1,6 +1,6 @@
 import string
 from dataclasses import dataclass
-from typing import Union, Optional, Any
+from typing import Union, Optional, Any, List, Tuple
 import re
 import pyparsing as pp
 
@@ -255,7 +255,7 @@ class Blend():
     weighted blend of the feature vectors to produce a single feature vector that is effectively a lerp between the
     Prompts.
     """
-    def __init__(self, prompts: list, weights: list[float], normalize_weights: bool=True):
+    def __init__(self, prompts: List, weights: List[List], normalize_weights: bool=True):
         #print("making Blend with prompts", prompts, "and weights", weights)
         weights = [1.0]*len(prompts) if (weights is None or len(weights)==0) else list(weights)
         if len(prompts) != len(weights):
@@ -331,7 +331,7 @@ class PromptParser():
         :return: A Conjunction containing the result of flattening each of the prompts in the passed-in root.
         """
 
-        def fuse_fragments(items) -> tuple[list, list]:
+        def fuse_fragments(items) -> Tuple[List, List]:
             # print("fusing fragments in ", items)
             fused_fragments = []
             extras = []

--- a/test/test_compel.py
+++ b/test/test_compel.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import List
 
 import torch
 
@@ -14,7 +15,7 @@ def make_dummy_compel():
     return Compel(tokenizer=tokenizer, text_encoder=text_encoder)
 
 
-def make_test_conditioning(text_encoder: DummyTransformer, tokenizer: DummyTokenizer, token_ids: list[int]) -> torch.Tensor:
+def make_test_conditioning(text_encoder: DummyTransformer, tokenizer: DummyTokenizer, token_ids: List[int]) -> torch.Tensor:
     pre_padding = [tokenizer.bos_token_id]
     token_ids = token_ids[0:tokenizer.model_max_length-2]
     post_padding = [tokenizer.eos_token_id] + [tokenizer.pad_token_id] * (tokenizer.model_max_length - len(token_ids) - 2)

--- a/test/test_prompt_parser.py
+++ b/test/test_prompt_parser.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import List, Tuple
 
 from src.compel.prompt_parser import PromptParser, Blend, Conjunction, FlattenedPrompt, CrossAttentionControlSubstitute, \
     Fragment, LoraWeight
@@ -11,11 +12,11 @@ def parse_prompt(prompt_string, verbose:bool = False):
     #print(f"-> parsed '{prompt_string}' to {parse_result}")
     return parse_result
 
-def make_basic_conjunction(strings: list[str]):
+def make_basic_conjunction(strings: List[str]):
     fragments = [Fragment(x) for x in strings]
     return Conjunction([FlattenedPrompt(fragments)])
 
-def make_weighted_conjunction(weighted_strings: list[tuple[str,float]]):
+def make_weighted_conjunction(weighted_strings: List[Tuple[str,float]]):
     fragments = [Fragment(x, w) for x,w in weighted_strings]
     return Conjunction([FlattenedPrompt(fragments)])
 


### PR DESCRIPTION
Hey @damian0815,

Super cool library you have built. We'd love to feature it more in `diffusers`. Many of our users use `diffusers` with Python 3.7 however. I wondered whether we can make the codebase compatible with 3.7 - think only the following changes are needed. I tested the changes with:

```
- `diffusers` version: 0.15.0.dev0
- Platform: Linux-4.19.0-23-cloud-amd64-x86_64-with-debian-10.13
- Python version: 3.7.3
- PyTorch version (GPU?): 1.13.1+cu116 (True)
- Transformers version: 4.27.0.dev0
```

All the tests also pass locally.