### PR TITLE
[API] Add __call__ method

### DIFF
--- a/src/compel/compel.py
+++ b/src/compel/compel.py
@@ -43,13 +43,14 @@ class Compel:
         conditioning, _ = self.build_conditioning_tensor_for_prompt_object(prompt_object)
         return conditioning
 
+    @torch.no_grad()
     def __call__(self, text: Union[str, List[str]]) -> torch.Tensor:
         if not isinstance(text, list):
             text = [text]
 
         cond_tensor = []
         for text_input in text:
-            cond_tensor.append(self.build_conditioning_tensor(text))
+            cond_tensor.append(self.build_conditioning_tensor(text_input))
 
         cond_tensor = torch.cat(cond_tensor)
 

--- a/src/compel/compel.py
+++ b/src/compel/compel.py
@@ -43,6 +43,18 @@ class Compel:
         conditioning, _ = self.build_conditioning_tensor_for_prompt_object(prompt_object)
         return conditioning
 
+    def __call__(self, text: Union[str, List[str]]) -> torch.Tensor:
+        if not isinstance(text, list):
+            text = [text]
+
+        cond_tensor = []
+        for text_input in text:
+            cond_tensor.append(self.build_conditioning_tensor(text))
+
+        cond_tensor = torch.cat(cond_tensor)
+
+        return cond_tensor
+
     @classmethod
     def parse_prompt_string(cls, prompt_string: str) -> Union[FlattenedPrompt, Blend]:
         pp = PromptParser()

--- a/src/compel/compel.py
+++ b/src/compel/compel.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Union, Optional, Callable
+from typing import Union, Optional, Callable, List
 
 import torch
 from transformers import CLIPTokenizer, CLIPTextModel


### PR DESCRIPTION
This PR is a bit dependent on: #3 

I think it could make sense to add a `__call__` method that also allows to take a list as an input and always returns a tensor of shape [bsz, seq_len, feature_dim] as it's usually done in ML IMO.

Also, I've added a `torch.no_grad()` decorator here so that gradients are never stored with this method to save memory. Think this makes sense as I don't really see prompt weighting to be used for training. 

Happy to write tests for it, but was wondering if @damian0815 could say before if this PR is desired or not.