### PR TITLE
Workaround for memory leak bug in clip library

### DIFF
--- a/src/compel/embeddings_provider.py
+++ b/src/compel/embeddings_provider.py
@@ -366,10 +366,11 @@ class EmbeddingsProvider:
         if self.use_penultimate_clip_layer:
             # needs normalizing
             penultimate_hidden_state = text_encoder_output.hidden_states[-2]
-            return self.text_encoder.text_model.final_layer_norm(penultimate_hidden_state)
+            return self.text_encoder.text_model.final_layer_norm(penultimate_hidden_state).detach().clone()
         else:
             # already normalized
-            return text_encoder_output.last_hidden_state
+            # detach().clone() necessary to work around a memory leak problem in the clip library
+            return text_encoder_output.last_hidden_state.detach().clone()
 
     def _get_token_ranges_for_fragments(self, chunked_and_padded_token_ids: List[int], fragments: List[str]) -> List[Tuple[int, int]]:
         """


### PR DESCRIPTION
This PR works around an apparent bug in the CLIP library which causes a portion of the text encoder model to get "stuck" in VRAM and not relocate to CPU when its `to()` method is called. The painful details can be found in this discord thread: https://discord.com/channels/1020123559063990373/1122971266123579454/1124946760285048852

