### PR TITLE
Fix broken cpu-offloading with SD XL (pooled embeddings)

### DIFF
--- a/src/compel/compel.py
+++ b/src/compel/compel.py
@@ -110,7 +110,7 @@ class Compel:
         conditioning, _ = self.build_conditioning_tensor_for_conjunction(conjunction)
 
         if self.requires_pooled:
-            pooled = self.conditioning_provider.get_pooled_embeddings([text])
+            pooled = self.conditioning_provider.get_pooled_embeddings([text], device=self.device)
             return conditioning, pooled
         else:
             return conditioning

--- a/src/compel/embeddings_provider.py
+++ b/src/compel/embeddings_provider.py
@@ -227,9 +227,14 @@ class EmbeddingsProvider:
 
         return result
 
-    def get_pooled_embeddings(self, texts: List[str], attention_mask: Optional[torch.Tensor]=None) -> Optional[torch.Tensor]:
+    def get_pooled_embeddings(
+        self, texts: List[str], attention_mask: Optional[torch.Tensor] = None, device: Optional[str] = None
+    ) -> Optional[torch.Tensor]:
+
+        device = device or self.text_encoder.device
+
         token_ids = self.get_token_ids(texts, padding="max_length")
-        token_ids = torch.tensor(token_ids, dtype=torch.long).to(self.text_encoder.device)
+        token_ids = torch.tensor(token_ids, dtype=torch.long).to(device)
 
         text_encoder_output = self.text_encoder(token_ids, attention_mask, return_dict=True)
         pooled = text_encoder_output.text_embeds
@@ -493,8 +498,11 @@ class EmbeddingsProviderMulti:
         # so for simplicity, we just return `get_token_ids` of the first tokenizer
         return self.embedding_providers[0].get_token_ids(self, *args, **kwargs)
 
-    def get_pooled_embeddings(self, texts: List[str], attention_mask: Optional[torch.Tensor]=None) -> Optional[torch.Tensor]:
-        pooled = [self.embedding_providers[provider_index].get_pooled_embeddings(texts, attention_mask)
+    def get_pooled_embeddings(
+        self, texts: List[str], attention_mask: Optional[torch.Tensor] = None, device: Optional[str] = None
+    ) -> Optional[torch.Tensor]:
+
+        pooled = [self.embedding_providers[provider_index].get_pooled_embeddings(texts, attention_mask, device=device)
                   for provider_index, requires_pooled in enumerate(self.requires_pooled_mask) if requires_pooled]
 
         if len(pooled) == 0:


### PR DESCRIPTION
Hi,

This is similar to https://github.com/damian0815/compel/pull/31

Allows compel to work with SD XL when `enable_sequential_cpu_offload()` is used in diffusers.

It's currently using the text_encoder's device, which would be `meta` after cpu offloading. That raises an error: `Cannot copy out of meta tensor; no data!`

All the tests seem to pass, and the change is backward-compatible.

Thanks!