### PR TITLE
Modernize Compel for Transformers 5 and add diffusers smoke coverage

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Note that cross-attention control `.swap()` is currently ignored by Compel, but 
 
 `pip install compel`
 
+Current main-branch support targets:
+
+- Python `>=3.10`
+- `transformers >=5,<6`
+
 ## Documentation
 
 Documentation is [here](doc/).
@@ -60,7 +65,7 @@ negative_prompt = "blurry, low quality, deformed"
 conditioning = compel(prompt, negative_prompt=negative_prompt)
 
 # generate image
-images = pipeline(prompt_embeds=conditioning.embeds, negative_prompt_embed=conditioning.negative_embeds, num_inference_steps=20).images
+images = pipeline(prompt_embeds=conditioning.embeds, negative_prompt_embeds=conditioning.negative_embeds, num_inference_steps=20).images
 images[0].save("image.jpg")
 ```
 
@@ -79,7 +84,7 @@ negative_prompt = ["blurry, low quality, deformed", "painting"]
 conditioning = compel(prompt, negative_prompt=negative_prompt)
 
 # generate image
-images = pipeline(prompt_embeds=conditioning.embeds, negative_prompt_embed=conditioning.negative_embeds, num_inference_steps=20).images
+images = pipeline(prompt_embeds=conditioning.embeds, negative_prompt_embeds=conditioning.negative_embeds, num_inference_steps=20).images
 images[0].save("image.jpg")
 ```
 
@@ -178,9 +183,25 @@ If this doesn't help, you could try this advice offered by @kshieh1:
 
 See https://github.com/damian0815/compel/issues/24 for more details. Thanks @kshieh1 !
 
+## Local Checkpoint Smoke Tests
+
+The default test suite uses tiny local diffusers components so it stays fast and CI-friendly.
+
+If you want to validate real local SDXL `.safetensors` checkpoints with `StableDiffusionXLPipeline.from_single_file(...)`,
+run:
+
+```bash
+COMPEL_RUN_LOCAL_CHECKPOINT_TESTS=1 python -m unittest test.test_diffusers_smoke -v
+```
+
+This opt-in path only uses local files and does not pull remote model weights.
+
 ## Changelog
 
 #### 2.3.1 - Fix for 78 tokens / 77 tokens issue with SDXL; add `device` arg to `CompelFor*` constructors (thanks @dx2-66)
+
+Current main-branch validation also includes opt-in local SDXL `.safetensors` single-file smoke tests for
+`StableDiffusionXLPipeline.from_single_file(...)`; see `COMPEL_RUN_LOCAL_CHECKPOINT_TESTS=1` above.
 
 ### 2.3.0 - Tokenization info, SplitLongTextMode CLS token handling, negative/style bugfixes
 
@@ -352,4 +373,3 @@ negative_conditioning = compel.build_conditioning_tensor(negative_prompt)
 #### 0.1.8 - downgrade Python min version to 3.7
 
 #### 0.1.7 - InvokeAI compatibility
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,14 @@ authors = [
 ]
 description = "A prompting enhancement library for transformers-type text embedding systems."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
@@ -17,7 +22,7 @@ dependencies = [
     "notebook>=6.5.7",
     "pyparsing ~= 3.0",
     "torch",
-    "transformers ~= 4.25",
+    "transformers >= 5, < 6",
 ]
 
 [project.urls]
@@ -27,4 +32,3 @@ dependencies = [
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyparsing
+pyparsing~=3.0
 torch
-transformers
+transformers>=5,<6
 diffusers

--- a/src/compel/convenience_wrappers.py
+++ b/src/compel/convenience_wrappers.py
@@ -3,7 +3,6 @@ from typing import Union, List, Optional, Any, Callable
 
 import torch
 from diffusers import FluxPipeline, StableDiffusionXLPipeline, StableDiffusionPipeline
-from networkx.algorithms.shortest_paths.weighted import negative_edge_cycle
 
 import compel.embeddings_provider
 from compel import Compel, ReturnedEmbeddingsType, BaseTextualInversionManager

--- a/src/compel/prompt_parser.py
+++ b/src/compel/prompt_parser.py
@@ -595,7 +595,7 @@ def build_parser_syntax(attention_plus_base: float, attention_minus_base: float)
         keyword  # flag
     ]))
     # options for an operator, eg "s_start=0.1, 0.3, no_normalize"
-    options = pp.Dict(pp.Optional(pp.delimited_list(option)))
+    options = pp.Dict(pp.Optional(pp.DelimitedList(option)))
     options.set_name('options')
     options.set_debug(False)
 
@@ -663,7 +663,7 @@ def build_parser_syntax(attention_plus_base: float, attention_minus_base: float)
     # a blend/lerp between the feature vectors for two or more prompts
     blend = (
         lparen
-        + pp.Group(pp.delimited_list(pp.Group(potential_operator_target | quoted_prompt), min=1)).set_name('bl-target').set_debug(False)
+        + pp.Group(pp.DelimitedList(pp.Group(potential_operator_target | quoted_prompt), min=1)).set_name('bl-target').set_debug(False)
         + rparen
         + pp.Literal(".blend").set_name('bl-operator').set_debug(False)
         + lparen
@@ -677,7 +677,7 @@ def build_parser_syntax(attention_plus_base: float, attention_minus_base: float)
     # an operator to direct stable diffusion to step multiple times, once for each target, and then add the results together with different weights
     explicit_conjunction = (
         lparen
-        + pp.Group(pp.delimited_list(pp.Group(potential_operator_target | quoted_prompt), min=1)).set_name('cj-target').set_debug(False)
+        + pp.Group(pp.DelimitedList(pp.Group(potential_operator_target | quoted_prompt), min=1)).set_name('cj-target').set_debug(False)
         + rparen
         + pp.one_of([".and", ".add"]).set_name('cj-operator').set_debug(False)
         + lparen
@@ -696,4 +696,3 @@ def build_parser_syntax(attention_plus_base: float, attention_minus_base: float)
     conjunction = (explicit_conjunction | implicit_conjunction)
 
     return conjunction, prompt
-

--- a/test/test_diffusers_smoke.py
+++ b/test/test_diffusers_smoke.py
@@ -1,0 +1,186 @@
+import gc
+import os
+import unittest
+from pathlib import Path
+
+import torch
+from diffusers import AutoencoderKL, EulerDiscreteScheduler, StableDiffusionPipeline, StableDiffusionXLPipeline, UNet2DConditionModel
+from transformers import CLIPTextConfig, CLIPTextModel, CLIPTextModelWithProjection
+
+from compel import CompelForSD, CompelForSDXL
+
+try:
+    from prompting_test_utils import DummyTokenizer
+except ModuleNotFoundError:
+    from test.prompting_test_utils import DummyTokenizer
+
+
+LOCAL_SDXL_CHECKPOINTS = {
+    "sd_xl_turbo": Path("/mnt/s/Code/Models/ImageGen/CUI-Archived/checkpoints/sd_xl_turbo_1.0_fp16.safetensors"),
+    "cyberrealisticXL_v80": Path("/mnt/s/Code/Models/ImageGen/CUI-Archived/checkpoints/cyberrealisticXL_v80_fp16.safetensors"),
+}
+RUN_LOCAL_CHECKPOINT_TESTS = os.getenv("COMPEL_RUN_LOCAL_CHECKPOINT_TESTS") == "1"
+
+
+def make_clip_text_config(hidden_size: int = 32, projection_dim: int = 32, max_position_embeddings: int = 16) -> CLIPTextConfig:
+    return CLIPTextConfig(
+        vocab_size=32,
+        hidden_size=hidden_size,
+        intermediate_size=37,
+        projection_dim=projection_dim,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        max_position_embeddings=max_position_embeddings,
+        bos_token_id=10,
+        pad_token_id=11,
+        eos_token_id=12,
+    )
+
+
+def make_tiny_vae() -> AutoencoderKL:
+    return AutoencoderKL(
+        in_channels=3,
+        out_channels=3,
+        down_block_types=["DownEncoderBlock2D"],
+        up_block_types=["UpDecoderBlock2D"],
+        block_out_channels=[32],
+        layers_per_block=1,
+        latent_channels=4,
+        norm_num_groups=8,
+        sample_size=32,
+    )
+
+
+def make_tiny_sd_unet(cross_attention_dim: int) -> UNet2DConditionModel:
+    return UNet2DConditionModel(
+        sample_size=32,
+        in_channels=4,
+        out_channels=4,
+        layers_per_block=1,
+        block_out_channels=(32, 64),
+        down_block_types=("CrossAttnDownBlock2D", "DownBlock2D"),
+        up_block_types=("UpBlock2D", "CrossAttnUpBlock2D"),
+        cross_attention_dim=cross_attention_dim,
+        attention_head_dim=(4, 8),
+        norm_num_groups=8,
+    )
+
+
+def make_tiny_sdxl_unet(cross_attention_dim: int, projection_dim: int) -> UNet2DConditionModel:
+    return UNet2DConditionModel(
+        sample_size=32,
+        in_channels=4,
+        out_channels=4,
+        layers_per_block=1,
+        block_out_channels=(32, 64),
+        down_block_types=("CrossAttnDownBlock2D", "DownBlock2D"),
+        up_block_types=("UpBlock2D", "CrossAttnUpBlock2D"),
+        cross_attention_dim=cross_attention_dim,
+        attention_head_dim=(4, 8),
+        norm_num_groups=8,
+        addition_embed_type="text_time",
+        addition_time_embed_dim=8,
+        projection_class_embeddings_input_dim=(8 * 6) + projection_dim,
+    )
+
+
+class DiffusersSmokeTestCase(unittest.TestCase):
+    def test_stable_diffusion_pipeline_accepts_compel_prompt_embeds(self):
+        tokenizer = DummyTokenizer(model_max_length=16)
+        text_encoder = CLIPTextModel(make_clip_text_config(hidden_size=32, projection_dim=32, max_position_embeddings=16))
+        pipe = StableDiffusionPipeline(
+            vae=make_tiny_vae(),
+            text_encoder=text_encoder,
+            tokenizer=tokenizer,
+            unet=make_tiny_sd_unet(cross_attention_dim=32),
+            scheduler=EulerDiscreteScheduler(num_train_timesteps=10, steps_offset=1),
+            safety_checker=None,
+            feature_extractor=None,
+            requires_safety_checker=False,
+        ).to("cpu")
+        pipe.set_progress_bar_config(disable=True)
+
+        conditioning = CompelForSD(pipe)("a b c", negative_prompt="a")
+        result = pipe(
+            prompt_embeds=conditioning.embeds,
+            negative_prompt_embeds=conditioning.negative_embeds,
+            num_inference_steps=1,
+            guidance_scale=2.0,
+            output_type="np",
+        )
+
+        self.assertEqual(conditioning.embeds.shape, (1, 16, 32))
+        self.assertEqual(conditioning.negative_embeds.shape, (1, 16, 32))
+        self.assertEqual(len(result.images), 1)
+        self.assertEqual(result.images[0].shape, (32, 32, 3))
+
+    def test_sdxl_pipeline_accepts_compel_prompt_and_pooled_embeds(self):
+        tokenizer = DummyTokenizer(model_max_length=16)
+        text_encoder = CLIPTextModel(make_clip_text_config(hidden_size=32, projection_dim=16, max_position_embeddings=16))
+        text_encoder_2 = CLIPTextModelWithProjection(
+            make_clip_text_config(hidden_size=32, projection_dim=16, max_position_embeddings=16)
+        )
+        pipe = StableDiffusionXLPipeline(
+            vae=make_tiny_vae(),
+            text_encoder=text_encoder,
+            text_encoder_2=text_encoder_2,
+            tokenizer=tokenizer,
+            tokenizer_2=DummyTokenizer(model_max_length=16),
+            unet=make_tiny_sdxl_unet(cross_attention_dim=64, projection_dim=16),
+            scheduler=EulerDiscreteScheduler(num_train_timesteps=10, steps_offset=1),
+            image_encoder=None,
+            feature_extractor=None,
+        ).to("cpu")
+        pipe.set_progress_bar_config(disable=True)
+
+        conditioning = CompelForSDXL(pipe)(
+            "a b c",
+            style_prompt="b c",
+            negative_prompt="a",
+            negative_style_prompt="a",
+        )
+        result = pipe(
+            prompt_embeds=conditioning.embeds,
+            pooled_prompt_embeds=conditioning.pooled_embeds,
+            negative_prompt_embeds=conditioning.negative_embeds,
+            negative_pooled_prompt_embeds=conditioning.negative_pooled_embeds,
+            num_inference_steps=1,
+            guidance_scale=2.0,
+            output_type="np",
+        )
+
+        self.assertEqual(conditioning.embeds.shape, (1, 16, 64))
+        self.assertEqual(conditioning.pooled_embeds.shape, (1, 16))
+        self.assertEqual(conditioning.negative_embeds.shape, (1, 16, 64))
+        self.assertEqual(conditioning.negative_pooled_embeds.shape, (1, 16))
+        self.assertEqual(len(result.images), 1)
+        self.assertEqual(result.images[0].shape, (32, 32, 3))
+
+
+@unittest.skipUnless(RUN_LOCAL_CHECKPOINT_TESTS, "set COMPEL_RUN_LOCAL_CHECKPOINT_TESTS=1 to run local checkpoint smoke tests")
+class LocalCheckpointSmokeTestCase(unittest.TestCase):
+    def test_sdxl_single_file_checkpoints_load_locally(self):
+        dtype = torch.float16 if torch.cuda.is_available() else torch.float32
+
+        for checkpoint_name, checkpoint_path in LOCAL_SDXL_CHECKPOINTS.items():
+            with self.subTest(checkpoint=checkpoint_name):
+                self.assertTrue(checkpoint_path.exists(), f"missing local checkpoint: {checkpoint_path}")
+
+                pipe = StableDiffusionXLPipeline.from_single_file(
+                    str(checkpoint_path),
+                    local_files_only=True,
+                    torch_dtype=dtype,
+                )
+                pipe.set_progress_bar_config(disable=True)
+
+                self.assertIsInstance(pipe, StableDiffusionXLPipeline)
+                self.assertIsNotNone(pipe.text_encoder)
+                self.assertIsNotNone(pipe.text_encoder_2)
+                self.assertGreater(pipe.unet.config.cross_attention_dim, 0)
+
+                del pipe
+                gc.collect()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_embeddings_provider.py
+++ b/test/test_embeddings_provider.py
@@ -3,7 +3,7 @@ import unittest
 
 import torch
 
-from src.compel.embeddings_provider import EmbeddingsProvider, DownweightMode, SplitLongTextMode
+from compel.embeddings_provider import EmbeddingsProvider, DownweightMode, ReturnedEmbeddingsType, SplitLongTextMode
 from prompting_test_utils import DummyTokenizer, DummyTransformer, KNOWN_WORDS, KNOWN_WORDS_TOKEN_IDS, NullTransformer
 
 
@@ -15,6 +15,45 @@ def make_dummy_embeddings_provider(max_length=10, embedding_length=768, **kwargs
 BOS = len(KNOWN_WORDS)
 PAD = BOS + 1
 EOS = BOS + 2
+
+
+class DummyTransformerWithPoolerOutput(DummyTransformer):
+    def forward(self, input_ids: torch.Tensor, attention_mask=None, output_hidden_states: bool = False, return_dict: bool = True):
+        output = super().forward(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+        output.pooler_output = output.last_hidden_state[:, 0, :]
+        return output
+
+
+class DummyT5Tokenizer(DummyTokenizer):
+    def __call__(self, fragments, **kwargs):
+        tokenized = [
+            [self.tokens.index(w) for w in fragment.split(" ")] + [self.eos_token_id]
+            if len(fragment) > 0
+            else [self.eos_token_id]
+            for fragment in fragments
+        ]
+        default_truncation = False
+        if kwargs.get("truncation", default_truncation):
+            max_length = kwargs.get("max_length", self.model_max_length)
+            tokenized = [x[0 : max_length - 1] + [self.eos_token_id] if len(x) > max_length else x for x in tokenized]
+        padding_strategy = kwargs.get("padding", "do_not_pad")
+        if padding_strategy not in ["do_not_pad", "max_length"]:
+            raise Exception(
+                "for unit tests only 'do_not_pad' and 'max_length' is supported "
+                f"as a padding strategy (got '{padding_strategy}')"
+            )
+
+        if padding_strategy == "max_length":
+            tokenized = [
+                tokens[:-1] + (self.model_max_length - len(tokens)) * [self.pad_token_id] + tokens[-1:] for tokens in tokenized
+            ]
+
+        return {"input_ids": tokenized}
 
 class EmbeddingsProviderTestCase(unittest.TestCase):
 
@@ -207,6 +246,73 @@ class EmbeddingsProviderTestCase(unittest.TestCase):
         #print(expected_token_ids_with_bos_eos)
         token_ids = ep.get_token_ids(prompts, include_start_and_end_markers=True, truncation_override=False)
         self.assertEqual(expected_token_ids_with_bos_eos, token_ids)
+
+    def test_get_token_ids_for_bosless_t5_style_tokenizer(self):
+        tokenizer = DummyT5Tokenizer(model_max_length=6)
+        tokenizer.bos_token_id = None
+        ep = EmbeddingsProvider(tokenizer=tokenizer, text_encoder=DummyTransformer(text_model_max_length=6))
+
+        token_ids = ep.get_token_ids(["a b c"], include_start_and_end_markers=False, truncation_override=False)
+        self.assertEqual([[0, 1, 2]], token_ids)
+
+        token_ids_with_markers = ep.get_token_ids(["a b c"], include_start_and_end_markers=True, truncation_override=False)
+        self.assertEqual([[0, 1, 2, tokenizer.eos_token_id]], token_ids_with_markers)
+
+    def test_chunking_for_bosless_t5_style_tokenizer(self):
+        tokenizer = DummyT5Tokenizer(model_max_length=6)
+        tokenizer.bos_token_id = None
+        ep = EmbeddingsProvider(
+            tokenizer=tokenizer,
+            text_encoder=DummyTransformer(text_model_max_length=6),
+            truncate=False,
+            padding_attention_mask_value=0,
+        )
+
+        token_ids_tensor, weights_tensor, mask = ep.get_token_ids_and_expand_weights(["a b c a b c a"], weights=[1.5], device="cpu")
+
+        self.assertTrue(
+            torch.equal(
+                token_ids_tensor,
+                torch.tensor([0, 1, 2, 0, 1, EOS, 2, 0, EOS, PAD, PAD, PAD], dtype=torch.int64),
+            )
+        )
+        self.assertTrue(torch.equal(weights_tensor, torch.tensor([1.5] * 5 + [1.0] + [1.5] * 2 + [1.0] + [1.0] * 3)))
+        self.assertTrue(torch.equal(mask, torch.tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0])))
+
+    def test_pooled_embeddings_use_pooler_output_when_present(self):
+        tokenizer = DummyTokenizer(model_max_length=5)
+        text_encoder = DummyTransformerWithPoolerOutput(text_model_max_length=5, embedding_length=7)
+        ep = EmbeddingsProvider(
+            tokenizer=tokenizer,
+            text_encoder=text_encoder,
+            returned_embeddings_type=ReturnedEmbeddingsType.POOLED,
+        )
+
+        pooled = ep.get_pooled_embeddings(["a b"], device="cpu")
+        token_ids = torch.tensor([[BOS, 0, 1, PAD, EOS]], dtype=torch.long)
+        expected = text_encoder(token_ids).pooler_output
+
+        self.assertEqual((1, 7), pooled.shape)
+        self.assertTrue(torch.allclose(expected, pooled, atol=1e-7))
+
+    def test_pooled_prompt_fragments_return_tokens_for_text_embeds_models(self):
+        tokenizer = DummyTokenizer(model_max_length=5)
+        text_encoder = DummyTransformer(text_model_max_length=5, embedding_length=7)
+        ep = EmbeddingsProvider(
+            tokenizer=tokenizer,
+            text_encoder=text_encoder,
+            returned_embeddings_type=ReturnedEmbeddingsType.POOLED,
+        )
+
+        pooled, token_ids = ep.get_embeddings_for_weighted_prompt_fragments(
+            [["a b"]],
+            [[1.0]],
+            should_return_tokens=True,
+            device="cpu",
+        )
+
+        self.assertEqual((1, 7), pooled.shape)
+        self.assertTrue(torch.equal(token_ids, torch.tensor([[BOS, 0, 1, EOS, PAD]], dtype=torch.long)))
 
 
     def test_build_weighted_embeddings_tensor(self):

--- a/test/test_prompt_parser.py
+++ b/test/test_prompt_parser.py
@@ -1,7 +1,7 @@
 import unittest
 from typing import List, Tuple
 
-from src.compel.prompt_parser import PromptParser, Blend, Conjunction, FlattenedPrompt, CrossAttentionControlSubstitute, \
+from compel.prompt_parser import PromptParser, Blend, Conjunction, FlattenedPrompt, CrossAttentionControlSubstitute, \
     Fragment, LoraWeight
 
 
@@ -373,7 +373,7 @@ class PromptParserTestCase(unittest.TestCase):
                                                                                                 't_end': 1.0}
                                                                                        )
                                                        ])]),
-                         parse_prompt("a cat.swap(dog) eating a hotdog.swap(h\(o\)tdog++++, shape_freedom=0.5)"))
+                         parse_prompt(r"a cat.swap(dog) eating a hotdog.swap(h\(o\)tdog++++, shape_freedom=0.5)"))
         self.assertEqual(Conjunction([FlattenedPrompt([Fragment('a', 1),
                                                        CrossAttentionControlSubstitute([Fragment('cat', 1)],
                                                                                        [Fragment('dog', 1)]),
@@ -386,7 +386,7 @@ class PromptParserTestCase(unittest.TestCase):
                                                                                                 't_end': 1.0}
                                                                                        )
                                                        ])]),
-                         parse_prompt("a cat.swap(dog) eating a hotdog.swap(\"h\(o\)tdog++++\", shape_freedom=0.5)"))
+                         parse_prompt("a cat.swap(dog) eating a hotdog.swap(\"h\\(o\\)tdog++++\", shape_freedom=0.5)"))
 
         self.assertEqual(Conjunction([FlattenedPrompt([Fragment('a', 1),
                                                        CrossAttentionControlSubstitute([Fragment('cat', 1)],
@@ -400,7 +400,7 @@ class PromptParserTestCase(unittest.TestCase):
                                                                                                 't_end': 1.0}
                                                                                        )
                                                        ])]),
-                         parse_prompt("a cat.swap(dog) eating a hotdog.swap(h\(o\)tdog-, shape_freedom=0.5)"))
+                         parse_prompt(r"a cat.swap(dog) eating a hotdog.swap(h\(o\)tdog-, shape_freedom=0.5)"))
 
 
     def test_cross_attention_control_options(self):
@@ -435,51 +435,51 @@ class PromptParserTestCase(unittest.TestCase):
 
         # make sure ", ( and ) can be escaped
 
-        self.assertEqual(make_basic_conjunction(['mountain (man)']),parse_prompt('mountain \(man\)'))
-        self.assertEqual(make_basic_conjunction(['mountain (man )']),parse_prompt('mountain (\(man)\)'))
-        self.assertEqual(make_basic_conjunction(['mountain (man)']),parse_prompt('mountain (\(man\))'))
-        self.assertEqual(make_weighted_conjunction([('mountain', 1), ('(man)', 1.1)]), parse_prompt('mountain (\(man\))+'))
-        self.assertEqual(make_weighted_conjunction([('mountain', 1), ('(man)', 1.1)]), parse_prompt('"mountain" (\(man\))+'))
-        self.assertEqual(make_weighted_conjunction([('"mountain"', 1), ('(man)', 1.1)]), parse_prompt('\\"mountain\\" (\(man\))+'))
+        self.assertEqual(make_basic_conjunction(['mountain (man)']),parse_prompt(r'mountain \(man\)'))
+        self.assertEqual(make_basic_conjunction(['mountain (man )']),parse_prompt(r'mountain (\(man)\)'))
+        self.assertEqual(make_basic_conjunction(['mountain (man)']),parse_prompt(r'mountain (\(man\))'))
+        self.assertEqual(make_weighted_conjunction([('mountain', 1), ('(man)', 1.1)]), parse_prompt(r'mountain (\(man\))+'))
+        self.assertEqual(make_weighted_conjunction([('mountain', 1), ('(man)', 1.1)]), parse_prompt(r'"mountain" (\(man\))+'))
+        self.assertEqual(make_weighted_conjunction([('"mountain"', 1), ('(man)', 1.1)]), parse_prompt(r'\\"mountain\\" (\(man\))+'))
         # same weights for each are combined into one
-        self.assertEqual(make_weighted_conjunction([('"mountain" (man)', 1.1)]), parse_prompt('(\\"mountain\\")+ (\(man\))+'))
-        self.assertEqual(make_weighted_conjunction([('"mountain"', 1.1), ('(man)', 0.9)]), parse_prompt('(\\"mountain\\")+ (\(man\))-'))
+        self.assertEqual(make_weighted_conjunction([('"mountain" (man)', 1.1)]), parse_prompt(r'(\\"mountain\\")+ (\(man\))+'))
+        self.assertEqual(make_weighted_conjunction([('"mountain"', 1.1), ('(man)', 0.9)]), parse_prompt(r'(\\"mountain\\")+ (\(man\))-'))
 
-        self.assertEqual(make_weighted_conjunction([('mountain', 1), ('\(man\)', 1.1)]),parse_prompt('mountain (\(man\))1.1'))
-        self.assertEqual(make_weighted_conjunction([('mountain', 1), ('\(man\)', 1.1)]),parse_prompt('"mountain" (\(man\))1.1'))
-        self.assertEqual(make_weighted_conjunction([('"mountain"', 1), ('\(man\)', 1.1)]),parse_prompt('\\"mountain\\" (\(man\))1.1'))
+        self.assertEqual(make_weighted_conjunction([('mountain', 1), (r'\(man\)', 1.1)]),parse_prompt(r'mountain (\(man\))1.1'))
+        self.assertEqual(make_weighted_conjunction([('mountain', 1), (r'\(man\)', 1.1)]),parse_prompt(r'"mountain" (\(man\))1.1'))
+        self.assertEqual(make_weighted_conjunction([('"mountain"', 1), (r'\(man\)', 1.1)]),parse_prompt(r'\\"mountain\\" (\(man\))1.1'))
         # same weights for each are combined into one
-        self.assertEqual(make_weighted_conjunction([('\\"mountain\\" \(man\)', 1.1)]),parse_prompt('(\\"mountain\\")+ (\(man\))1.1'))
-        self.assertEqual(make_weighted_conjunction([('\\"mountain\\"', 1.1), ('\(man\)', 0.9)]),parse_prompt('(\\"mountain\\")1.1 (\(man\))0.9'))
+        self.assertEqual(make_weighted_conjunction([(r'"mountain" \(man\)', 1.1)]),parse_prompt(r'(\\"mountain\\")+ (\(man\))1.1'))
+        self.assertEqual(make_weighted_conjunction([(r'"mountain"', 1.1), (r'\(man\)', 0.9)]),parse_prompt(r'(\\"mountain\\")1.1 (\(man\))0.9'))
 
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain', 1.1), ('\(man\)', 1.1*1.1)]),parse_prompt('hairy (mountain (\(man\))+)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('\(man\)', 1.1*1.1), ('mountain', 1.1)]),parse_prompt('hairy ((\(man\))1.1 "mountain")+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain', 1.1), ('\(man\)', 1.1*1.1)]),parse_prompt('hairy ("mountain" (\(man\))1.1 )+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain', 1.1), (r'\(man\)', 1.1*1.1)]),parse_prompt(r'hairy (mountain (\(man\))+)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), (r'\(man\)', 1.1*1.1), ('mountain', 1.1)]),parse_prompt(r'hairy ((\(man\))1.1 "mountain")+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain', 1.1), (r'\(man\)', 1.1*1.1)]),parse_prompt(r'hairy ("mountain" (\(man\))1.1 )+'))
         self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , man', 1.1)]),parse_prompt('hairy ("mountain, man")+'))
         self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , man with a', 1.1), ('beard', 1.1*1.1)]), parse_prompt('hairy ("mountain, man" with a beard+)+'))
         self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , man with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, man" with a (beard)2.0)+'))
         self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man\" with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\"man\\"" with a (beard)2.0)+'))
         self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , m\"an\" with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, m\\"an\\"" with a (beard)2.0)+'))
 
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man (with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man\" \(with a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man w(ith a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man\" w\(ith a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man with( a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man\" with\( a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man )with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man\" \)with a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man\" w\)ith a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man with) a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man\" with\) a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mou)ntain , \"man (wit(h a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mou\)ntain, \\\"man\" \(wit\(h a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hai(ry', 1), ('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hai\(ry ("mountain, \\\"man\" w\)ith a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy((', 1), ('mountain , \"man with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy\(\( ("mountain, \\\"man\" with a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man (with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man" \\(with a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man w(ith a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man" w\\(ith a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man with( a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man" with\\( a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man )with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man" \\)with a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man" w\\)ith a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man with) a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man" with\\) a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mou)ntain , \"man (wit(h a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mou\\)ntain, \\\"man" \\(wit\\(h a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hai(ry', 1), ('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hai\\(ry ("mountain, \\\"man" w\\)ith a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy((', 1), ('mountain , \"man with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy\\(\\( ("mountain, \\\"man" with a (beard)2.0)+'))
 
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man (with a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man\" \(with a (beard)2.0)+ hairy'))
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man w(ith a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man\" w\(ith a (beard)2.0)+hairy'))
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man with( a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man\" with\( a (beard)2.0)+ hairy'))
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man )with a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man\" \)with a (beard)2.0)+ hairy'))
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man\" w\)ith a (beard)2.0)+ hairy'))
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man with) a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt(' ("mountain, \\\"man\" with\) a (beard)2.0)+ hairy'))
-        self.assertEqual(make_weighted_conjunction([('mou)ntain , \"man (wit(h a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mou\)ntain, \\\"man\" \(wit\(h a (beard)2.0)+ hairy'))
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0), ('hai(ry', 1)]), parse_prompt('("mountain, \\\"man\" w\)ith a (beard)2.0)+ hai\(ry '))
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man with a', 1.1), ('beard', 1.1*2.0), ('hairy((', 1)]), parse_prompt('("mountain, \\\"man\" with a (beard)2.0)+ hairy\(\( '))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man (with a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man" \\(with a (beard)2.0)+ hairy'))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man w(ith a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man" w\\(ith a (beard)2.0)+hairy'))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man with( a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man" with\\( a (beard)2.0)+ hairy'))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man )with a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man" \\)with a (beard)2.0)+ hairy'))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man" w\\)ith a (beard)2.0)+ hairy'))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man with) a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt(' ("mountain, \\\"man" with\\) a (beard)2.0)+ hairy'))
+        self.assertEqual(make_weighted_conjunction([('mou)ntain , \"man (wit(h a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mou\\)ntain, \\\"man" \\(wit\\(h a (beard)2.0)+ hairy'))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0), ('hai(ry', 1)]), parse_prompt('("mountain, \\\"man" w\\)ith a (beard)2.0)+ hai\\(ry '))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man with a', 1.1), ('beard', 1.1*2.0), ('hairy((', 1)]), parse_prompt('("mountain, \\\"man" with a (beard)2.0)+ hairy\\(\\( '))
 
     def test_cross_attention_escaping(self):
 
@@ -488,13 +488,13 @@ class PromptParserTestCase(unittest.TestCase):
                          parse_prompt('mountain (man).swap(monkey)'))
         self.assertEqual(Conjunction([FlattenedPrompt(
             [('mountain', 1), CrossAttentionControlSubstitute([Fragment('man', 1)], [Fragment('m(onkey', 1)])])]),
-                         parse_prompt('mountain (man).swap(m\(onkey)'))
+                         parse_prompt(r'mountain (man).swap(m\(onkey)'))
         self.assertEqual(Conjunction([FlattenedPrompt(
             [('mountain', 1), CrossAttentionControlSubstitute([Fragment('m(an', 1)], [Fragment('m(onkey', 1)])])]),
-                         parse_prompt('mountain (m\(an).swap(m\(onkey)'))
+                         parse_prompt(r'mountain (m\(an).swap(m\(onkey)'))
         self.assertEqual(Conjunction([FlattenedPrompt(
             [('mountain', 1), CrossAttentionControlSubstitute([Fragment('(((', 1)], [Fragment('m(on))key', 1)])])]),
-                         parse_prompt('mountain (\(\(\().swap(m\(on\)\)key)'))
+                         parse_prompt(r'mountain (\(\(\().swap(m\(on\)\)key)'))
 
         self.assertEqual(Conjunction([FlattenedPrompt(
             [('mountain', 1), CrossAttentionControlSubstitute([Fragment('man', 1)], [Fragment('monkey', 1)])])]),
@@ -507,13 +507,13 @@ class PromptParserTestCase(unittest.TestCase):
                          parse_prompt('mountain (\\"man).swap("monkey")'))
         self.assertEqual(Conjunction([FlattenedPrompt(
             [('mountain', 1), CrossAttentionControlSubstitute([Fragment('man', 1)], [Fragment('m(onkey', 1)])])]),
-                         parse_prompt('mountain (man).swap(m\(onkey)'))
+                         parse_prompt(r'mountain (man).swap(m\(onkey)'))
         self.assertEqual(Conjunction([FlattenedPrompt(
             [('mountain', 1), CrossAttentionControlSubstitute([Fragment('m(an', 1)], [Fragment('m(onkey', 1)])])]),
-                         parse_prompt('mountain (m\(an).swap(m\(onkey)'))
+                         parse_prompt(r'mountain (m\(an).swap(m\(onkey)'))
         self.assertEqual(Conjunction([FlattenedPrompt(
             [('mountain', 1), CrossAttentionControlSubstitute([Fragment('(((', 1)], [Fragment('m(on))key', 1)])])]),
-                         parse_prompt('mountain (\(\(\().swap(m\(on\)\)key)'))
+                         parse_prompt(r'mountain (\(\(\().swap(m\(on\)\)key)'))
 
     """
     def test_legacy_blend(self):

--- a/test/test_prompt_parser.py
+++ b/test/test_prompt_parser.py
@@ -1,7 +1,7 @@
 import unittest
 from typing import List, Tuple
 
-from compel.prompt_parser import PromptParser, Blend, Conjunction, FlattenedPrompt, CrossAttentionControlSubstitute, \
+from src.compel.prompt_parser import PromptParser, Blend, Conjunction, FlattenedPrompt, CrossAttentionControlSubstitute, \
     Fragment, LoraWeight
 
 
@@ -373,7 +373,7 @@ class PromptParserTestCase(unittest.TestCase):
                                                                                                 't_end': 1.0}
                                                                                        )
                                                        ])]),
-                         parse_prompt(r"a cat.swap(dog) eating a hotdog.swap(h\(o\)tdog++++, shape_freedom=0.5)"))
+                         parse_prompt("a cat.swap(dog) eating a hotdog.swap(h\(o\)tdog++++, shape_freedom=0.5)"))
         self.assertEqual(Conjunction([FlattenedPrompt([Fragment('a', 1),
                                                        CrossAttentionControlSubstitute([Fragment('cat', 1)],
                                                                                        [Fragment('dog', 1)]),
@@ -386,7 +386,7 @@ class PromptParserTestCase(unittest.TestCase):
                                                                                                 't_end': 1.0}
                                                                                        )
                                                        ])]),
-                         parse_prompt("a cat.swap(dog) eating a hotdog.swap(\"h\\(o\\)tdog++++\", shape_freedom=0.5)"))
+                         parse_prompt("a cat.swap(dog) eating a hotdog.swap(\"h\(o\)tdog++++\", shape_freedom=0.5)"))
 
         self.assertEqual(Conjunction([FlattenedPrompt([Fragment('a', 1),
                                                        CrossAttentionControlSubstitute([Fragment('cat', 1)],
@@ -400,7 +400,7 @@ class PromptParserTestCase(unittest.TestCase):
                                                                                                 't_end': 1.0}
                                                                                        )
                                                        ])]),
-                         parse_prompt(r"a cat.swap(dog) eating a hotdog.swap(h\(o\)tdog-, shape_freedom=0.5)"))
+                         parse_prompt("a cat.swap(dog) eating a hotdog.swap(h\(o\)tdog-, shape_freedom=0.5)"))
 
 
     def test_cross_attention_control_options(self):
@@ -435,51 +435,51 @@ class PromptParserTestCase(unittest.TestCase):
 
         # make sure ", ( and ) can be escaped
 
-        self.assertEqual(make_basic_conjunction(['mountain (man)']),parse_prompt(r'mountain \(man\)'))
-        self.assertEqual(make_basic_conjunction(['mountain (man )']),parse_prompt(r'mountain (\(man)\)'))
-        self.assertEqual(make_basic_conjunction(['mountain (man)']),parse_prompt(r'mountain (\(man\))'))
-        self.assertEqual(make_weighted_conjunction([('mountain', 1), ('(man)', 1.1)]), parse_prompt(r'mountain (\(man\))+'))
-        self.assertEqual(make_weighted_conjunction([('mountain', 1), ('(man)', 1.1)]), parse_prompt(r'"mountain" (\(man\))+'))
-        self.assertEqual(make_weighted_conjunction([('"mountain"', 1), ('(man)', 1.1)]), parse_prompt(r'\\"mountain\\" (\(man\))+'))
+        self.assertEqual(make_basic_conjunction(['mountain (man)']),parse_prompt('mountain \(man\)'))
+        self.assertEqual(make_basic_conjunction(['mountain (man )']),parse_prompt('mountain (\(man)\)'))
+        self.assertEqual(make_basic_conjunction(['mountain (man)']),parse_prompt('mountain (\(man\))'))
+        self.assertEqual(make_weighted_conjunction([('mountain', 1), ('(man)', 1.1)]), parse_prompt('mountain (\(man\))+'))
+        self.assertEqual(make_weighted_conjunction([('mountain', 1), ('(man)', 1.1)]), parse_prompt('"mountain" (\(man\))+'))
+        self.assertEqual(make_weighted_conjunction([('"mountain"', 1), ('(man)', 1.1)]), parse_prompt('\\"mountain\\" (\(man\))+'))
         # same weights for each are combined into one
-        self.assertEqual(make_weighted_conjunction([('"mountain" (man)', 1.1)]), parse_prompt(r'(\\"mountain\\")+ (\(man\))+'))
-        self.assertEqual(make_weighted_conjunction([('"mountain"', 1.1), ('(man)', 0.9)]), parse_prompt(r'(\\"mountain\\")+ (\(man\))-'))
+        self.assertEqual(make_weighted_conjunction([('"mountain" (man)', 1.1)]), parse_prompt('(\\"mountain\\")+ (\(man\))+'))
+        self.assertEqual(make_weighted_conjunction([('"mountain"', 1.1), ('(man)', 0.9)]), parse_prompt('(\\"mountain\\")+ (\(man\))-'))
 
-        self.assertEqual(make_weighted_conjunction([('mountain', 1), (r'\(man\)', 1.1)]),parse_prompt(r'mountain (\(man\))1.1'))
-        self.assertEqual(make_weighted_conjunction([('mountain', 1), (r'\(man\)', 1.1)]),parse_prompt(r'"mountain" (\(man\))1.1'))
-        self.assertEqual(make_weighted_conjunction([('"mountain"', 1), (r'\(man\)', 1.1)]),parse_prompt(r'\\"mountain\\" (\(man\))1.1'))
+        self.assertEqual(make_weighted_conjunction([('mountain', 1), ('\(man\)', 1.1)]),parse_prompt('mountain (\(man\))1.1'))
+        self.assertEqual(make_weighted_conjunction([('mountain', 1), ('\(man\)', 1.1)]),parse_prompt('"mountain" (\(man\))1.1'))
+        self.assertEqual(make_weighted_conjunction([('"mountain"', 1), ('\(man\)', 1.1)]),parse_prompt('\\"mountain\\" (\(man\))1.1'))
         # same weights for each are combined into one
-        self.assertEqual(make_weighted_conjunction([(r'"mountain" \(man\)', 1.1)]),parse_prompt(r'(\\"mountain\\")+ (\(man\))1.1'))
-        self.assertEqual(make_weighted_conjunction([(r'"mountain"', 1.1), (r'\(man\)', 0.9)]),parse_prompt(r'(\\"mountain\\")1.1 (\(man\))0.9'))
+        self.assertEqual(make_weighted_conjunction([('\\"mountain\\" \(man\)', 1.1)]),parse_prompt('(\\"mountain\\")+ (\(man\))1.1'))
+        self.assertEqual(make_weighted_conjunction([('\\"mountain\\"', 1.1), ('\(man\)', 0.9)]),parse_prompt('(\\"mountain\\")1.1 (\(man\))0.9'))
 
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain', 1.1), (r'\(man\)', 1.1*1.1)]),parse_prompt(r'hairy (mountain (\(man\))+)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), (r'\(man\)', 1.1*1.1), ('mountain', 1.1)]),parse_prompt(r'hairy ((\(man\))1.1 "mountain")+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain', 1.1), (r'\(man\)', 1.1*1.1)]),parse_prompt(r'hairy ("mountain" (\(man\))1.1 )+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain', 1.1), ('\(man\)', 1.1*1.1)]),parse_prompt('hairy (mountain (\(man\))+)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('\(man\)', 1.1*1.1), ('mountain', 1.1)]),parse_prompt('hairy ((\(man\))1.1 "mountain")+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain', 1.1), ('\(man\)', 1.1*1.1)]),parse_prompt('hairy ("mountain" (\(man\))1.1 )+'))
         self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , man', 1.1)]),parse_prompt('hairy ("mountain, man")+'))
         self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , man with a', 1.1), ('beard', 1.1*1.1)]), parse_prompt('hairy ("mountain, man" with a beard+)+'))
         self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , man with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, man" with a (beard)2.0)+'))
         self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man\" with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\"man\\"" with a (beard)2.0)+'))
         self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , m\"an\" with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, m\\"an\\"" with a (beard)2.0)+'))
 
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man (with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man" \\(with a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man w(ith a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man" w\\(ith a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man with( a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man" with\\( a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man )with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man" \\)with a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man" w\\)ith a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man with) a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man" with\\) a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mou)ntain , \"man (wit(h a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mou\\)ntain, \\\"man" \\(wit\\(h a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hai(ry', 1), ('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hai\\(ry ("mountain, \\\"man" w\\)ith a (beard)2.0)+'))
-        self.assertEqual(make_weighted_conjunction([('hairy((', 1), ('mountain , \"man with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy\\(\\( ("mountain, \\\"man" with a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man (with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man\" \(with a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man w(ith a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man\" w\(ith a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man with( a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man\" with\( a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man )with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man\" \)with a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man\" w\)ith a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mountain , \"man with) a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mountain, \\\"man\" with\) a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy', 1), ('mou)ntain , \"man (wit(h a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy ("mou\)ntain, \\\"man\" \(wit\(h a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hai(ry', 1), ('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hai\(ry ("mountain, \\\"man\" w\)ith a (beard)2.0)+'))
+        self.assertEqual(make_weighted_conjunction([('hairy((', 1), ('mountain , \"man with a', 1.1), ('beard', 1.1*2.0)]), parse_prompt('hairy\(\( ("mountain, \\\"man\" with a (beard)2.0)+'))
 
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man (with a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man" \\(with a (beard)2.0)+ hairy'))
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man w(ith a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man" w\\(ith a (beard)2.0)+hairy'))
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man with( a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man" with\\( a (beard)2.0)+ hairy'))
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man )with a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man" \\)with a (beard)2.0)+ hairy'))
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man" w\\)ith a (beard)2.0)+ hairy'))
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man with) a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt(' ("mountain, \\\"man" with\\) a (beard)2.0)+ hairy'))
-        self.assertEqual(make_weighted_conjunction([('mou)ntain , \"man (wit(h a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mou\\)ntain, \\\"man" \\(wit\\(h a (beard)2.0)+ hairy'))
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0), ('hai(ry', 1)]), parse_prompt('("mountain, \\\"man" w\\)ith a (beard)2.0)+ hai\\(ry '))
-        self.assertEqual(make_weighted_conjunction([('mountain , \"man with a', 1.1), ('beard', 1.1*2.0), ('hairy((', 1)]), parse_prompt('("mountain, \\\"man" with a (beard)2.0)+ hairy\\(\\( '))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man (with a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man\" \(with a (beard)2.0)+ hairy'))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man w(ith a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man\" w\(ith a (beard)2.0)+hairy'))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man with( a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man\" with\( a (beard)2.0)+ hairy'))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man )with a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man\" \)with a (beard)2.0)+ hairy'))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mountain, \\\"man\" w\)ith a (beard)2.0)+ hairy'))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man with) a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt(' ("mountain, \\\"man\" with\) a (beard)2.0)+ hairy'))
+        self.assertEqual(make_weighted_conjunction([('mou)ntain , \"man (wit(h a', 1.1), ('beard', 1.1*2.0), ('hairy', 1)]), parse_prompt('("mou\)ntain, \\\"man\" \(wit\(h a (beard)2.0)+ hairy'))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man w)ith a', 1.1), ('beard', 1.1*2.0), ('hai(ry', 1)]), parse_prompt('("mountain, \\\"man\" w\)ith a (beard)2.0)+ hai\(ry '))
+        self.assertEqual(make_weighted_conjunction([('mountain , \"man with a', 1.1), ('beard', 1.1*2.0), ('hairy((', 1)]), parse_prompt('("mountain, \\\"man\" with a (beard)2.0)+ hairy\(\( '))
 
     def test_cross_attention_escaping(self):
 
@@ -488,13 +488,13 @@ class PromptParserTestCase(unittest.TestCase):
                          parse_prompt('mountain (man).swap(monkey)'))
         self.assertEqual(Conjunction([FlattenedPrompt(
             [('mountain', 1), CrossAttentionControlSubstitute([Fragment('man', 1)], [Fragment('m(onkey', 1)])])]),
-                         parse_prompt(r'mountain (man).swap(m\(onkey)'))
+                         parse_prompt('mountain (man).swap(m\(onkey)'))
         self.assertEqual(Conjunction([FlattenedPrompt(
             [('mountain', 1), CrossAttentionControlSubstitute([Fragment('m(an', 1)], [Fragment('m(onkey', 1)])])]),
-                         parse_prompt(r'mountain (m\(an).swap(m\(onkey)'))
+                         parse_prompt('mountain (m\(an).swap(m\(onkey)'))
         self.assertEqual(Conjunction([FlattenedPrompt(
             [('mountain', 1), CrossAttentionControlSubstitute([Fragment('(((', 1)], [Fragment('m(on))key', 1)])])]),
-                         parse_prompt(r'mountain (\(\(\().swap(m\(on\)\)key)'))
+                         parse_prompt('mountain (\(\(\().swap(m\(on\)\)key)'))
 
         self.assertEqual(Conjunction([FlattenedPrompt(
             [('mountain', 1), CrossAttentionControlSubstitute([Fragment('man', 1)], [Fragment('monkey', 1)])])]),
@@ -507,13 +507,13 @@ class PromptParserTestCase(unittest.TestCase):
                          parse_prompt('mountain (\\"man).swap("monkey")'))
         self.assertEqual(Conjunction([FlattenedPrompt(
             [('mountain', 1), CrossAttentionControlSubstitute([Fragment('man', 1)], [Fragment('m(onkey', 1)])])]),
-                         parse_prompt(r'mountain (man).swap(m\(onkey)'))
+                         parse_prompt('mountain (man).swap(m\(onkey)'))
         self.assertEqual(Conjunction([FlattenedPrompt(
             [('mountain', 1), CrossAttentionControlSubstitute([Fragment('m(an', 1)], [Fragment('m(onkey', 1)])])]),
-                         parse_prompt(r'mountain (m\(an).swap(m\(onkey)'))
+                         parse_prompt('mountain (m\(an).swap(m\(onkey)'))
         self.assertEqual(Conjunction([FlattenedPrompt(
             [('mountain', 1), CrossAttentionControlSubstitute([Fragment('(((', 1)], [Fragment('m(on))key', 1)])])]),
-                         parse_prompt(r'mountain (\(\(\().swap(m\(on\)\)key)'))
+                         parse_prompt('mountain (\(\(\().swap(m\(on\)\)key)'))
 
     """
     def test_legacy_blend(self):

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -1,0 +1,94 @@
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from compel import Compel, CompelForSD, CompelForSDXL
+
+from prompting_test_utils import DummyTokenizer, DummyTransformer
+
+
+class DummyT5Tokenizer(DummyTokenizer):
+    def __call__(self, fragments, **kwargs):
+        tokenized = [
+            [self.tokens.index(w) for w in fragment.split(" ")] + [self.eos_token_id]
+            if len(fragment) > 0
+            else [self.eos_token_id]
+            for fragment in fragments
+        ]
+        default_truncation = False
+        if kwargs.get("truncation", default_truncation):
+            max_length = kwargs.get("max_length", self.model_max_length)
+            tokenized = [
+                x[0 : max_length - 1] + [self.eos_token_id] if len(x) > max_length else x
+                for x in tokenized
+            ]
+        padding_strategy = kwargs.get("padding", "do_not_pad")
+        if padding_strategy not in ["do_not_pad", "max_length"]:
+            raise Exception(
+                "for unit tests only 'do_not_pad' and 'max_length' is supported "
+                f"as a padding strategy (got '{padding_strategy}')"
+            )
+
+        if padding_strategy == "max_length":
+            tokenized = [
+                tokens[:-1]
+                + (self.model_max_length - len(tokens)) * [self.pad_token_id]
+                + tokens[-1:]
+                for tokens in tokenized
+            ]
+
+        return {"input_ids": tokenized}
+
+
+class SmokeTestCase(unittest.TestCase):
+    def test_public_api_imports(self):
+        from compel import Compel as ImportedCompel
+        from compel import CompelForSD as ImportedCompelForSD
+
+        self.assertIs(ImportedCompel, Compel)
+        self.assertIs(ImportedCompelForSD, CompelForSD)
+
+    def test_clip_backed_path(self):
+        compel = Compel(tokenizer=DummyTokenizer(), text_encoder=DummyTransformer())
+
+        conditioning = compel("a b c")
+
+        self.assertEqual(conditioning.shape, (1, 77, 768))
+
+    def test_compel_for_sd_wrapper_with_negative_prompt(self):
+        pipeline = MagicMock()
+        pipeline.tokenizer = DummyTokenizer(model_max_length=5)
+        pipeline.text_encoder = DummyTransformer(text_model_max_length=5)
+
+        conditioning = CompelForSD(pipeline)("a b c", negative_prompt="a")
+
+        self.assertEqual(conditioning.embeds.shape, (1, 5, 768))
+        self.assertEqual(conditioning.negative_embeds.shape, (1, 5, 768))
+
+    def test_sdxl_style_path_returns_pooled_embeddings(self):
+        pipeline = MagicMock()
+        pipeline.tokenizer = DummyTokenizer(model_max_length=5)
+        pipeline.tokenizer_2 = DummyTokenizer(model_max_length=5)
+        pipeline.text_encoder = DummyTransformer(text_model_max_length=5, embedding_length=1280)
+        pipeline.text_encoder_2 = DummyTransformer(text_model_max_length=5, embedding_length=768)
+
+        conditioning = CompelForSDXL(pipeline)("a b c", style_prompt="b c")
+
+        self.assertEqual(conditioning.embeds.shape, (1, 5, 2048))
+        self.assertEqual(conditioning.pooled_embeds.shape, (1, 768))
+
+    def test_t5_backed_path_if_supported(self):
+        tokenizer = DummyT5Tokenizer(model_max_length=6)
+        tokenizer.bos_token_id = None
+        text_encoder = DummyTransformer(text_model_max_length=6)
+        compel = Compel(tokenizer=tokenizer, text_encoder=text_encoder)
+
+        conditioning = compel("a b c")
+
+        self.assertEqual(conditioning.shape, (1, 6, 768))
+        self.assertEqual(conditioning.dtype, torch.float32)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Modernizes Compel for current `transformers` / `diffusers` usage.

## Changes

- raise support floor to Python `>=3.10`
- update `transformers` guidance to `>=5,<6`
- align CI with supported Python versions
- add smoke coverage for public API imports, CLIP, SD, SDXL, and T5-style paths
- add diffusers smoke tests for `prompt_embeds` / `pooled_prompt_embeds`
- add opt-in local SDXL single-file checkpoint smoke coverage
- add provider-level tests for pooled output handling and BOS-less T5 behavior
- clean up README examples and parser deprecations

## Validation

- `PYTHONPATH=src:test .venv/bin/python -m unittest discover -s test -v`
- `COMPEL_RUN_LOCAL_CHECKPOINT_TESTS=1 .venv/bin/python -m unittest test.test_diffusers_smoke -v`
- editable install verified with `.venv/bin/python -m pip install -e . --no-build-isolation`